### PR TITLE
feat: add vrf type device to ip_link_device

### DIFF
--- a/.github/workflows/ansible-test.yaml
+++ b/.github/workflows/ansible-test.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
+          pip install flake8==4.0.0 pytest==6.2.4
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Install kernel extra modules
         run: sudo apt-get install -y linux-modules-extra-$(uname -r)

--- a/ansible_collections/amarao/ip/galaxy.yml
+++ b/ansible_collections/amarao/ip/galaxy.yml
@@ -3,7 +3,7 @@ namespace: amarao
 
 name: ip
 
-version: 0.1.10
+version: 0.1.11
 
 readme: README.md
 

--- a/ansible_collections/amarao/ip/plugins/modules/ip_address.py
+++ b/ansible_collections/amarao/ip/plugins/modules/ip_address.py
@@ -21,7 +21,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: ip_address
-version_added: "2.10"
+version_added: "0.0.1"
 author: "George Shuklin (@amarao)"
 short_description: Create or delete IP addresses on interfaces
 requirements: [iproute2]

--- a/ansible_collections/amarao/ip/plugins/modules/ip_link_device_attribute.py
+++ b/ansible_collections/amarao/ip/plugins/modules/ip_link_device_attribute.py
@@ -24,7 +24,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
 ---
 module: ip_link_device_attribute
-version_added: "2.10"
+version_added: "0.0.1"
 author: "George Shuklin (@amarao)"
 short_description: Set link-level properties for network interfaces for Linux
 requirements: [iproute2]

--- a/ansible_collections/amarao/ip/tests/integration/targets/ip_link_device/tasks/main.yaml
+++ b/ansible_collections/amarao/ip/tests/integration/targets/ip_link_device/tasks/main.yaml
@@ -531,3 +531,29 @@
         - 'ip link del veth42'
         - 'ip link del bond42'
       failed_when: false
+
+
+# TEST10 created vrf interface
+- name: TEST10 - vrf creation
+  tags: [test10]
+  become: true
+  block:
+    - name: TEST10, create vrf
+      ip_link_device:
+        device: vrf-blue
+        type: vrf
+        state: present
+        vrf_options:
+          table: 42
+    - name: TEST10, get results
+      command: ip -d link show dev vrf-blue
+      register: ip_output
+    - name: TEST9, check results
+      assert:
+        that:
+          - "'vrf-blue' in ip_output.stdout"
+          - "'table 42' in ip_output.stdout"
+  always:
+    - name: TEST10, cleanup
+      command: ip link del vrf-blue
+      failed_when: false


### PR DESCRIPTION
Add support for `type vrf` interfaces.

Also, I've pin down older versions for flake8/pytest to avoid intra-dependencies conflicts.